### PR TITLE
fix minification problem; automatically wrap element in span

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you do not want to the logic to trigger from the `placeholder` attribute, ple
 .config(function(floatLabelProvider) {
 		floatLabelProvider.setAttributeName('floatLabel');
 })
- ```
+```
 
 
 ### CSS
@@ -44,9 +44,28 @@ Example
 ---------
 Please view the [demo](http://www.chrisronline.com/angular-float-labels/index.html)
 
+Minification
+--------------------
+If you're using the Rails assets pipeline or UglifyJS, be sure to use
+v0.1.1 (or later), which includes annotation for the `$parse` dependency.
+For concatenated + minified Javascript with Angular >1.3, you can force
+function annotation checking with:
+
+```
+<!-- auto bootstrapping -->
+<div ng-app="myApp" ng-strict-di>
+```
+
+or
+
+```
+// manual bootstrapping
+angular.bootstrap(document.body, ['myApp'], { strictDi: true});
+```
 
 Release Notes
 ---------
+- v0.1.1 - Fix minification issues and auto-wrap input element
 - v0.1.0 - Add support for a custom attribute instead of `placeholder`
 - v0.0.7 - Fix validity check
 - v0.0.6 - see v0.0.5

--- a/angular-float-labels.js
+++ b/angular-float-labels.js
@@ -2,13 +2,14 @@
   'use strict';
 
   angular.module('angular-float-labels', [])
-    .directive('placeholder', function($parse) {
+    .directive('placeholder', ['$parse', function($parse) {
       return {
         restrict: 'A',
         link: function($scope, $element, $attrs) {
-          var label = $('<label class="angular-float-labels-label"></label').html($attrs.placeholder);
+          var label = $('<label class="angular-float-labels-label"></label>').html($attrs.placeholder);
           var element = $element;
           var input = $element;
+          element.wrap($('<span></span>'));
           var parent = element.parent().addClass('angular-float-labels-wrapper');
           var index = element.index();
 
@@ -73,5 +74,5 @@
           });
         }
       };
-    });
+    }]);
 })();

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-float-labels",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": [
     "angular-float-labels.js",
     "angular-float-labels.css"


### PR DESCRIPTION
- bump patch version

I found this issue via Rails asset pipeline applying JS concatenation + minification. Directive needs to declare the `'$parse'` dependency as a string.

Also, having multiple inputs within the same parent element causes the floating labels to be drawn over each other (positioning is relative to the parent), so I added `element.wrap...` to ensure each input has its own span parent.
